### PR TITLE
Wrong import file NonTransferable should have uppercase T

### DIFF
--- a/src/guide/dapp/dapp-integration.md
+++ b/src/guide/dapp/dapp-integration.md
@@ -155,8 +155,8 @@ Alternatively, you can obtain the contracts directly from the GitHub repository 
    import "@bnb-chain/greenfield-contracts-sdk/ObjectApp.sol";
    import "@bnb-chain/greenfield-contracts-sdk/GroupApp.sol";
    import "@bnb-chain/greenfield-contracts-sdk/interface/IERC1155.sol";
-   import "@bnb-chain/greenfield-contracts-sdk/interface/IERC721Nontransferable.sol";
-   import "@bnb-chain/greenfield-contracts-sdk/interface/IERC1155Nontransferable.sol";
+   import "@bnb-chain/greenfield-contracts-sdk/interface/IERC721NonTransferable.sol";
+   import "@bnb-chain/greenfield-contracts-sdk/interface/IERC1155NonTransferable.sol";
    ...
    
    contract EbookShop is BucketApp, ObjectApp, GroupApp {


### PR DESCRIPTION
this code contains a Type.

the interface is called "NonTrasferable"

### Description

Changed the "t" for "T"

### Rationale

The file is wrong, Remix is throwing an error, not rocket science.