### PR TITLE
Update Published Date on Merge

### DIFF
--- a/src/.vuepress/components/DateInfo.ts
+++ b/src/.vuepress/components/DateInfo.ts
@@ -1,0 +1,92 @@
+import { ClientOnly, usePageData, usePageLang } from "@vuepress/client"
+import { type PropType, type VNode, defineComponent, h } from "vue"
+
+import { CalendarIcon } from "@theme-hope/modules/info/components/icons"
+import { useMetaLocale } from "@theme-hope/modules/info/composables/index"
+
+/**
+ * @description Displays the published date at the top of articles
+ * 
+ * @summary     This component modifies the Hope Theme DateInfo component to use the updateTime value 
+ *              from git where available. If the metadata doesn't exist it will default to the standard 
+ *              functionality of showing the first published date.  
+ * 
+ * @dev         This component is transpiled by the theme which has access to @theme-hope and doesn't need
+ *              to be added as an additional package.
+ */
+export default defineComponent({
+  name: "DateInfo",
+
+  inheritAttrs: false,
+
+  props: {
+    /**
+     * Date information
+     *
+     * 日期信息
+     */
+    date: {
+      type: Object as PropType<Date | null>,
+      default: null,
+    },
+
+    /**
+     * Localized date text
+     *
+     * 本地化的日期文字
+     */
+    localizedDate: {
+      type: String,
+      default: "",
+    },
+
+    /**
+     * Whether in pure mode
+     *
+     * 是否处于纯净模式
+     */
+    pure: Boolean,
+  },
+
+  setup(props) {
+    const lang = usePageLang()
+    const metaLocale = useMetaLocale()
+    const page = usePageData()
+
+    const updateTime = page.value["git"]?.updatedTime
+      ? new Date(page.value["git"]?.updatedTime)
+      : null
+
+    return (): VNode | null =>
+      updateTime || props.date
+        ? h(
+            "span",
+            {
+              class: "page-date-info",
+              "aria-label": `${metaLocale.value.date}${props.pure ? "" : "📅"}`,
+              ...(props.pure ? {} : { "data-balloon-pos": "down" }),
+            },
+            [
+              h(CalendarIcon),
+              h(
+                "span",
+                h(ClientOnly, () =>
+                  updateTime
+                    ? updateTime.toLocaleDateString(lang.value)
+                    : props.localizedDate || props.date!.toLocaleDateString(lang.value),
+                ),
+              ),
+              h("meta", {
+                property: "datePublished",
+                // ISO Format Date string
+                content: updateTime
+                  ? updateTime.toISOString()
+                  : props.date
+                  ? props.date.toISOString()
+                  : "",
+              }),
+            ],
+          )
+        : null
+  },
+})

--- a/src/.vuepress/components/DateInfo.ts
+++ b/src/.vuepress/components/DateInfo.ts
@@ -72,7 +72,7 @@ export default defineComponent({
                 "span",
                 h(ClientOnly, () =>
                   updateTime
-                    ? updateTime.toLocaleDateString(lang.value)
+                    ? updateTime.toLocaleDateString(lang.value, { month: "long", day: "numeric", year: "numeric" })
                     : props.localizedDate || props.date!.toLocaleDateString(lang.value),
                 ),
               ),

--- a/src/.vuepress/config.ts
+++ b/src/.vuepress/config.ts
@@ -1,6 +1,7 @@
 import { defineUserConfig } from "vuepress";
 import { searchProPlugin } from "vuepress-plugin-search-pro";
-import { redirectPlugin } from 'vuepress-plugin-redirect';
+import { redirectPlugin } from "vuepress-plugin-redirect";
+import { getDirname, path } from "@vuepress/utils";
 import theme from "./theme.js";
 
 const base = process.env.BASE_PATH ? process.env.BASE_PATH : "/";
@@ -46,4 +47,15 @@ export default defineUserConfig({
     redirectPlugin({
     }),
   ],
+
+  alias: {
+    // Redirect aliases to modified theme components
+    //
+    // The modified DateInfo component displays the last published date rather than the
+    // first published date so it is easier to see if a document has recently changed. 
+    "@theme-hope/modules/info/components/DateInfo": path.resolve(
+      getDirname(import.meta.url),
+      "./components/DateInfo.ts",
+    ),
+  },
 });


### PR DESCRIPTION
### Description

This PR modifies the DateInput component from Hope to use the last published date of a document at the top of the page instead of the fist published date to make it easier for users to see if guidance was updated since they last used it. 

The component is identical to the one used by Hope but adds a check using the usePageData method to see if there is a git updatedTime and uses that if possible, if unavailable it reverts to the standard behaviour. This component is added by setting an alias to the modified component in the config which replaces the original.

Note: To test the project must be built as the date does not show in dev mode. This does not differ from the original component. 

### Rationale

While deploying a node I was having issues. When I looked to the docs for answers I saw the date at the top of the page was several months old and assumed they had not been changed since I last used them. Later I realised they had changed but the last update date was at the bottom of the page. 

Before change: 

<img width="530" alt="Screenshot 2023-06-09 at 15 43 03" src="https://github.com/bnb-chain/greenfield-docs/assets/30601942/bcd8cd0a-ce9d-44fd-a342-ce7c2e0f538a">

After change:

<img width="537" alt="Screenshot 2023-06-09 at 15 57 27" src="https://github.com/bnb-chain/greenfield-docs/assets/30601942/5cd3e835-d24c-4485-8e41-52da80d77597">

