### PR TITLE
Update default branch in github actions for deployment

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -3,7 +3,7 @@ name: Test deployment
 on:
   pull_request:
     branches:
-      - master
+      - main
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 


### PR DESCRIPTION
changed the default branch to point to "Main" instead of "Master"