### PR TITLE
Update docusaurus.config.js to include externalUrlRegex

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,7 +67,7 @@ const config = {
         // contextualSearch: true,
   
         // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
-        //externalUrlRegex: 'external\\.com|domain\\.com',
+        externalUrlRegex: 'https://docs.bnbchain.org/',
   
         // Optional: Algolia search parameters
         //searchParameters: {},


### PR DESCRIPTION
added configuration to navigate search results through window.location instead of history.push to avoid 404 error