### PR TITLE
update sp testnet runbook

### DIFF
--- a/docs/guide/storage-provider/run-book/common-issues.md
+++ b/docs/guide/storage-provider/run-book/common-issues.md
@@ -7,14 +7,18 @@ This is a list of solutions to common SP deployment issues
 
 ## On-chain Proposal
 
-### 1. Why is Proposal Rejected?
+### 1. Why send tx failed?
+
+* Reason 1: The gnfd binary doesn't match, you should use the [latest version](https://github.com/bnb-chain/greenfield/releases/latest)
+* Reason 2: The chain ID doesn't match, you should specify the chain ID correctly. For greenfield testnet, you should add `--chain-id "greenfield_5600-1"`
+
+### 2. Why is Proposal Rejected?
 
 If your proposal received less than 2/3 of `yes` votes from validators, your propoosal will be rejected.
 
-### 2. Why is Proposal Failed
+### 3. Why is Proposal Failed
 
-* Reason 1: The proposal initiator address does not have balance of **1k BNB** as deposit
-* Reason 2: The proposal initiator address does not grant gov module to spend 1k BNB, as instructed [here](https://docs.bnbchain.org/greenfield-docs/docs/guide/storage-provider/run-book/run-testnet-SP-node#1-authorization)
+The proposal initiator should be the funding address, and it should have balance of **1k BNB** as deposit.
 
 ## SP node issues
 

--- a/docs/guide/storage-provider/run-book/run-testnet-SP-node.md
+++ b/docs/guide/storage-provider/run-book/run-testnet-SP-node.md
@@ -203,29 +203,13 @@ You can query the governance parameters [here](https://docs.bnbchain.org/greenfi
 | Storage Provider Proposal Deposit | 0.00003 BNB |
 | Edit Storage Provider     |  0.1BNB       |
 
-
-### 1. Authorization
-
-Before creating the storage provider, it is necessary to allow the module account of the gov module to deduct the tokens from the funding account specified by the SP, because the addition of CreateStorageProvider requires submitting a proposal to the gov module, and only after enough validators approve can the SP be truly created on the chain and provide services externally. The address of the gov module account is `0x7b5Fe22B5446f7C62Ea27B8BD71CeF94e03f3dF2`.
-
-```shell
-./build/bin/gnfd keys show operator --keyring-backend os 
-./build/bin/gnfd tx sp grant 0x7b5Fe22B5446f7C62Ea27B8BD71CeF94e03f3dF2 --spend-limit 1000000000000000000000BNB --SPAddress {operator_address} --from {funding_address} --keyring-backend os --node https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org:443 
-```
-
-The above command requires the funding account of the SP to send the transaction to allow the gov module to have permission to deduct tokens from the funding account of SP which is specified by the operator address.
-
-:::note
-You can execute this command to query on-chain parameters. `./gnfd q sp params --node https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org:443`
-:::
-
-### 2. Submit-proposal
+### 1. Submit-proposal
 
 The SP needs to initiate an on-chain proposal that specifies the Msg information to be automatically executed after the vote is approved. In this case, the Msg is `MsgCreateStorageProvider`. It's worth noting that the deposit tokens needs to be greater than the minimum deposit tokens specified on the chain.
 
 ```shell
 
-./build/bin/gnfd tx sp create-storage-provider path/to/create_storage_provider.json --from funding  --node https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org:443
+./build/bin/gnfd tx sp create-storage-provider path/to/create_storage_provider.json --from funding  --node https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org:443 --chain-id "greenfield_5600-1"
 
 # create_sp.json
 $ cat ./create_sp.json
@@ -281,7 +265,7 @@ curl -X GET "https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org/cosmos/aut
 * `creator` is the address of `gov module` 
 * `metadata` is optional
 
-### 3. Deposit BNB to proposal
+### 2. Deposit BNB to proposal
 
 :::note
 You can get the mininum deposit for proposal by the above command. Please make sure that the initial deposit is greater than `min_deposit` when submitting the proposal.
@@ -295,10 +279,10 @@ You can skip this step if the initial deposit amount is greater than the min dep
 Each proposal needs to deposit enough tokens to enter the voting phase.
 
 ```shell
-./build/bin/gnfd tx gov deposit {proposal_id} 1BNB --from {funding_address} --keyring-backend os --node https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org:443
+./build/bin/gnfd tx gov deposit {proposal_id} 1BNB --from {funding_address} --keyring-backend os --node https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org:443 --chain-id "greenfield_5600-1"
 ```
 
-### 4. Wait voting and check voting result
+### 3. Wait voting and check voting result
 
 After submitting the proposal successfully, you must wait for the voting to be completed and the proposal to be approved. It will last **7 days** on mainnet while **1 day** on testnet. Once it has passed and is executed successfully, you can verify that the storage provider has been joined.
 


### PR DESCRIPTION
## Description

Remove authorization step and add chain id.

## Rationale

1. The authorization step has already included in create sp transaction.
2. When sending tx on testnet, we should specify the chain id correctly.