### PR TITLE
docs: update payment docs for global price

### DIFF
--- a/docs/guide/core-concept/billing-payment.md
+++ b/docs/guide/core-concept/billing-payment.md
@@ -25,7 +25,7 @@ storage will be mainly only related to time and the base price.
 
 Users are granted a free, time-based quota for downloading data, with each bucket corresponding to a set of their
 objects. If the quota is exceeded, users can upgrade their data package to obtain additional quota. The price for each
-data package is fixed for a certain period (unless the primary storage provider updates the read price and the user
+data package is fixed for a certain period (unless the read price has been changed and the user
 takes some actions to reflect the price change), during which users will only be charged based on the amount of time
 they spend downloading and the package price. This charging scheme remains in effect until the user modifies their data
 package settings.

--- a/docs/guide/greenfield-blockchain/modules/billing-and-payment.md
+++ b/docs/guide/greenfield-blockchain/modules/billing-and-payment.md
@@ -155,7 +155,8 @@ their in-flow calculation.
 Every time users do the actions below, their `StreamRecord` will
 be updated:
 
-- Creating an object will create new streams to the SPs;
+- Creating an object will create new streams to the Global Virtual Groups
+  and Global Virtual Group Family;
 
 - Deleting an object will delete associated streams to the Global Virtual Groups
   and Global Virtual Group Family;
@@ -296,29 +297,35 @@ is resumed.
 
 ### Storage Fee Price and Adjustment
 
-The storage fee prices are determined by the SPs who supply the storage service.
-The cost of the SPs are composed of 3 parts:
+The cost of **object storage fee** and **data package fee** are composed of 3 parts:
 
 - The primary SP will store the whole object file;
 - The secondary SPs will store part of the object file as a replica;
 - The primary SP will supply all the download requests of the object.
 
-There are 3 different on-chain prices:
+Hence, there are 3 different on-chain prices globally, which are used to charge storage 
+and download:
 
 - Primary SP Store Price;
+- Secondary SP Store Price,
 - Primary SP Read Price;
-- Secondary SP Store Price.
 
-Every SP can set their own store price and read price via on-chain transactions.
-While the secondary SP store price is calculated as the median all SPs' store price.
+Every SP can set their own suggested store price and read price via on-chain transactions.
+At the first block of each month, the median all SPs' store prices will be calculated as 
+the Primary SP Store Price, the Secondary SP Store Price will be calculated as a proportion 
+of the Primary SP Store Price (e.g. 12%), and the median of all SPs' read prices will be 
+calculated as the Primary SP Read Price.
+
+To make the global prices predictable to users and avoid price war, during the last two days 
+of a month all SPs are not allowed to set their own suggested prices.
 
 The unit of price is a decimal, which indicates wei BNB per byte per second.
 E.g. the price is 0.027, means approximately $0.022 / GB / Month.
 (`0.027 * (30 * 86400) * (1024 * 1024 * 1024) * 300 / 10 ** 18 ≈ 0.022`, assume the BNB price is 300 USD)
 
 The storage fees are calculated and charged in bucket level.
-The store price and read price is up to the SP of bucket.
-The secondary store price is stored in the chain state and the same for all buckets.
+The primary store price, secondary store price, and primary read price are stored in the chain state 
+and the same for all buckets at a specific time.
 The total size of all objects and per Global Virtual Group served size in a bucket will be recorded in the bucket
 metadata.
 The charge size will be used instead of the real size, e.g. files under 1KB will be charged as 1KB to cover the cost.

--- a/docs/guide/greenfield-blockchain/modules/billing-and-payment.md
+++ b/docs/guide/greenfield-blockchain/modules/billing-and-payment.md
@@ -307,14 +307,14 @@ Hence, there are 3 different on-chain prices globally, which are used to charge 
 and download:
 
 - Primary SP Store Price;
-- Secondary SP Store Price,
 - Primary SP Read Price;
+- Secondary SP Store Price.
 
 Every SP can set their own suggested store price and read price via on-chain transactions.
 At the first block of each month, the median all SPs' store prices will be calculated as 
 the Primary SP Store Price, the Secondary SP Store Price will be calculated as a proportion 
-of the Primary SP Store Price (e.g. 12%), and the median of all SPs' read prices will be 
-calculated as the Primary SP Read Price.
+of the Primary SP Store Price (e.g. 12%, which can be governed), and the median of all SPs' 
+read prices will be calculated as the Primary SP Read Price.
 
 To make the global prices predictable to users and avoid price war, during the last two days 
 of a month all SPs are not allowed to set their own suggested prices.

--- a/docs/guide/greenfield-blockchain/modules/storage-provider.md
+++ b/docs/guide/greenfield-blockchain/modules/storage-provider.md
@@ -120,7 +120,7 @@ message Params {
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",
     (gogoproto.nullable) = false
   ];
-  // the ratio of the store price of the secondary sp to the primary sp, the default value is 80%
+  // the ratio of the store price of the secondary sp to the primary sp, the default value is 12%
   string secondary_sp_store_price_ratio = 3 [
     (cosmos_proto.scalar) = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
@@ -236,6 +236,7 @@ This message is expected to fail if:
 * The storage provider doesn't exist;
 * The tokens that are deposited do not belong to the denomination that is specified as the deposit denomination of the SP module.
 
+### MsgUpdateStorageProviderStatus
 
 ```protobuf
 // MsgUpdateStorageProviderStatus is used to update the status of a SP by itself
@@ -252,3 +253,37 @@ This message is expected to fail if:
 * The storage provider doesn't exist;
 * The status is not changed
 * The restrictions violated
+
+### UpdateSpStoragePrice
+
+A storage provider can update its free read quote, suggested primary store price and read price. All SPs' suggested primary store and 
+read prices will be used to generate the global primary/secondary store price and read price. 
+
+```protobuf
+// MsgUpdateSpStoragePrice defines a SDK message to update its prices of a SP.
+message MsgUpdateSpStoragePrice {
+  option (cosmos.msg.v1.signer) = "sp_address";
+
+  // sp address
+  string sp_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // read price, in bnb wei per charge byte
+  string read_price = 2 [
+    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable) = false
+  ];
+  // free read quota, in byte
+  uint64 free_read_quota = 3;
+  // store price, in bnb wei per charge byte
+  string store_price = 4 [
+    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable) = false
+  ];
+}
+```
+
+This message is expected to fail if:
+
+* The storage provider doesn't exist;
+* The storage provider tries to update its prices in the last `update_price_disallowed_days` (default value is 2) days.


### PR DESCRIPTION
## Description

Update docs to use `global` storage prices.

## Rationale

To align the new changes.
