### PR TITLE
fix: tutorials/dapp sidbar item

### DIFF
--- a/docs/tutorials/dapp/contract-list.md
+++ b/docs/tutorials/dapp/contract-list.md
@@ -1,3 +1,8 @@
+---
+title: Contract Entrypoint
+order: 7
+---
+
 # Contract Entrypoint
 
 ## Testnet

--- a/docs/tutorials/dapp/dapp-integration.md
+++ b/docs/tutorials/dapp/dapp-integration.md
@@ -1,3 +1,8 @@
+---
+title: Integrating BSC Smart Contracts with Greenfield Projects
+order: 4
+---
+
 # Contract SDK
 
 The [Smart Contract SDK](https://github.com/bnb-chain/greenfield-contracts-sdk),

--- a/docs/tutorials/dapp/permission-control.md
+++ b/docs/tutorials/dapp/permission-control.md
@@ -1,3 +1,8 @@
+---
+title: Permission Control
+order: 5
+---
+
 # Permission Control 
 
 ## General Permission Control

--- a/docs/tutorials/dapp/primitive-interface.md
+++ b/docs/tutorials/dapp/primitive-interface.md
@@ -1,3 +1,8 @@
+---
+title: Primitive Interfaces
+order: 6
+---
+
 # Primitive Interfaces
 
 This document give a detailed introduction of cross-chain primitives that have been defined on BSC to enable developers to 

--- a/sidebars.js
+++ b/sidebars.js
@@ -264,7 +264,11 @@ const sidebars = {
           items:[
             "tutorials/dapp/overview",
             "tutorials/dapp/quick-start",
-            "tutorials/dapp/showcases"
+            "tutorials/dapp/dapp-integration",
+            "tutorials/dapp/permission-control",
+            "tutorials/dapp/primitive-interface",
+            "tutorials/dapp/contract-list",
+            "tutorials/dapp/showcases",
           ]
         },
         {


### PR DESCRIPTION
## Description

fix: tutorials/dapp sidbar item
<img width="454" alt="image" src="https://github.com/bnb-chain/greenfield-docs/assets/25412254/9464bf53-61d8-48bf-8405-6664b087c176">

## Rationale

some folder missing
