### PR TITLE
change the wrong sidebars

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -86,7 +86,7 @@ const sidebars = {
         
         {
           type: "category",
-          label: "Run Storage Provider",
+          label: "Run Node",
           collapsible: true,
           collapsed: true,
           items:[


### PR DESCRIPTION
## Description

Fix a wrong sidebar, it should be `run node`
![image](https://github.com/bnb-chain/greenfield-docs/assets/7310198/84fd6818-1ba9-49a5-b42a-109f7a328fe0)


## Rationale

tell us why we need these changes...
