### PR TITLE
change the order of navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -81,21 +81,20 @@ const config = {
             to: "/docs/guide/introduction/overview"
           },
           {
+            label: "Tutorials",
+            position: "left",
+            to: "/docs/tutorials/overview"
+          },
+          {
             //type: 'dropdown',
             label: "API & SDK",
             position: "left",
             to: "/docs/api/endpoints",
           },
-          
           {
             label: "Releases",
             position:"left",
             to: "/docs/release-notes/releaseNotes"
-          },
-          {
-            label: "Tutorials",
-            position: "left",
-            to: "/docs/tutorials/overview"
           },
           {
             label: "FAQs",


### PR DESCRIPTION
## Description

`Tutorials` is more important, it should be the second place.

## Rationale

No