### PR TITLE
doc: add the Prerequisite for Becoming a mainnet S

### DIFF
--- a/docs/guide/storage-provider/run-book/join-SP-network.md
+++ b/docs/guide/storage-provider/run-book/join-SP-network.md
@@ -21,6 +21,12 @@ This guide will help you join Greenfield SP Network: Mainnet and Testnet.
 - [Tools](#tools)
 - [Trouble Shooting](#trouble-shooting)
 
+## Prerequisite for Becoming a Mainnet SP
+To ensure the stable provision of data services, Storage Providers must meet specific criteria to join the mainnet.
+- The SP must join the testnet for a minimum of one month.
+- The SP must store over 1K files across more than 100 buckets on the testnet.
+- There were fewer than 500 slash events on the SP in the past month.
+
 ## How to Join SP Network?
 
 Greenfield Blockchain validators are responsible for selecting storage providers. For each on-chain proposal to add new storage provider, there are deposit period for depositing BNB and voting period for validators to make votes. Once the proposal passes, new SP can join the network afterwards.


### PR DESCRIPTION
## Description
Currently, we lack a clear specification regarding the criteria for voting on whether an SP can enter the mainnet.

## Rationale

This proposal aims to establish preconditions for the inclusion of an SP into the network, enhancing the overall governance process.
