### PR TITLE
update prerequisite for becoming a mainnet SP

### DIFF
--- a/docs/guide/storage-provider/run-book/join-SP-network.md
+++ b/docs/guide/storage-provider/run-book/join-SP-network.md
@@ -26,7 +26,7 @@ This guide will help you join Greenfield SP Network: Mainnet and Testnet.
 To ensure the stable provision of data services, Storage Providers must meet specific criteria to join the mainnet.
 - The SP must join the testnet for a minimum of one month.
 - The SP must store over 1K files across more than 100 buckets on the testnet.
-- There were fewer than 500 slash events on the SP in the past month.
+- There were no slash event on the SP in the past week.
 
 ## How to Join SP Network?
 


### PR DESCRIPTION
## Description

Update prerequisite for becoming a mainnet SP.

## Rationale

The SP should demonstrate data storage proficiency on the testnet to establish their stability for becoming a Mainnet SP.