### PR TITLE
Update general-faqs.md

### DIFF
--- a/docs/faq/general-faqs.md
+++ b/docs/faq/general-faqs.md
@@ -75,3 +75,9 @@ You can mirror your data and access permissions to the BNB Smart Chain network, 
 ### How long can the data uploaded to the testnet be saved?
 
 Testnet is used for testing, so it won't keep user's data for a long time. It is expected to be dropped after 7 days.
+
+### Why I cannot view my folder on DCellar when uploading an object through gnfd-cmd?
+
+Currently, gnfd-cmd does not allow you to specify content-type. Therefore, if the content-type is not correctly parsed, it will defaults to binary and results in direct downloading. The team is looking into supporting it in future developments.
+
+


### PR DESCRIPTION
Why I cannot view my folder on DCellar when uploading an object through gnfd-cmd?

## Description

Currently, gnfd-cmd does not allow you to specify content-type. Therefore, if the content-type is not correctly parsed, it will defaults to binary and results in direct downloading. The team is looking into supporting it in future developments.
## Rationale

tell us why we need these changes...
To inform user about gnfd-cmd and pick the correct method 