### PR TITLE
Update endpoints.md

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -35,6 +35,7 @@ order: 3
   - `https://bsc-dataseed.ninicoin.io`
   - `https://bsc.nodereal.io`
   - `https://bsc-dataseed-public.bnbchain.org`
+  - `https://bsc.drpc.org`
 
   You could find more endpoints from [here](https://chainlist.org/chain/56).
 
@@ -43,6 +44,7 @@ order: 3
   - `https://opbnb-mainnet-rpc.bnbchain.org`
   - `https://opbnb-mainnet.nodereal.io/v1/64a9df0874fb4a93b9d0a3849de012d3`
   - `https://opbnb-mainnet.nodereal.io/v1/e9a36765eb8a40b9bd12e680a1fd2bc5`
+  - `https://opbnb.drpc.org`
 
   For more details, you can refer to [here](https://docs.bnbchain.org/opbnb-docs/docs/build-on-opbnb/opbnb-network-info).
 
@@ -82,5 +84,6 @@ order: 3
   - `https://opbnb-testnet-rpc.bnbchain.org`
   - `https://opbnb-testnet.nodereal.io/v1/64a9df0874fb4a93b9d0a3849de012d3`
   - `https://opbnb-testnet.nodereal.io/v1/e9a36765eb8a40b9bd12e680a1fd2bc5`
+  - `https://opbnb-testnet.drpc.org`
 
   For more details, you can refer to [here](https://docs.bnbchain.org/opbnb-docs/docs/build-on-opbnb/opbnb-network-info).


### PR DESCRIPTION
Added dRPC endpoints to the list.

dRPC is decentralized RPC node providers for BSC and opBNB.

## Description

dRPC is decentralized RPC node providers for BSC and opBNB.

## Rationale

dRPC is one of the top node providers so it would be beneficial for builders of bsc and opbnb.